### PR TITLE
Hide autogenerated elements like Solved, Lab, Assignments, etc

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -16,7 +16,7 @@ function genSidebarConfig(doc) { // referenced from FOSSonTOP(credit to @PugzAre
     underscoreToSpace: true,
     includeEmptyFolder: false,
     sortMenusByName: false,
-    excludePattern: ['README**'],
+    excludePattern: ['README**', 'solved.md', 'lab.md', 'assignment.md'],
     sortMenusByFrontmatterOrder: true,
     includeFolderIndexFile: true,
     useTitleFromFrontmatter: true


### PR DESCRIPTION
This change is done because the links are accessible from the sem-level "home" page as well - having it here will do nothing more than clutter up the sidebar.